### PR TITLE
less specific material inventory kicks for bags

### DIFF
--- a/files/scripts/utils/inventory.lua
+++ b/files/scripts/utils/inventory.lua
@@ -6,8 +6,8 @@ local function get_entities_with_material_inventory_in_radius(x,y,r)
 	local out={}
 	for i=1,#ents do
 		local eid=ents[i]
-		if EntityGetFirstComponentIncludingDisabled(eid,"MaterialInventoryComponent") and not EntityGetFirstComponentIncludingDisabled(eid,"ControlsComponent") and not EntityHasTag(eid,"player_unit") then
-		--so basically, look for anything with a material component, but blacklist anything with a controls component. this is to ensure things which can eat cannot be placed in a bag. for extra security, check for the player_unit tag in case some other mod messes with the player, because otherwise, the player gets placed in the bag, which, while hilarious, bricks the save.
+		if EntityGetFirstComponentIncludingDisabled(eid,"MaterialInventoryComponent") and EntityHasTag(eid,"item_pickup") then
+		--so basically, look for anything with a material component, and make sure that it is an item - because things other than potions have a MaterialInventoryComponent, such as the player - and putting the player inside a bag softlocks the save (pretty funny).
 			out[#out+1]=ents[i]
 		end
 	end

--- a/files/scripts/utils/inventory.lua
+++ b/files/scripts/utils/inventory.lua
@@ -1,6 +1,19 @@
 dofile_once( "mods/bags_of_many/files/scripts/utils/utils.lua" )
 dofile_once( "mods/bags_of_many/files/scripts/utils/noita_utils.lua" )
 
+local function get_entities_with_material_inventory_in_radius(x,y,r)
+	local ents=EntityGetInRadius(x,y,r)
+	local out={}
+	for i=1,#ents do
+		local eid=ents[i]
+		if EntityGetFirstComponentIncludingDisabled(eid,"MaterialInventoryComponent") and not EntityGetFirstComponentIncludingDisabled(eid,"ControlsComponent") and not EntityHasTag(eid,"player_unit") then
+		--so basically, look for anything with a material component, but blacklist anything with a controls component. this is to ensure things which can eat cannot be placed in a bag. for extra security, check for the player_unit tag in case some other mod messes with the player, because otherwise, the player gets placed in the bag, which, while hilarious, bricks the save.
+			out[#out+1]=ents[i]
+		end
+	end
+	return out
+end
+
 local pickup_distance = 20
 
 function bag_pickup_action(entity_who_kicked, active_item)
@@ -36,7 +49,7 @@ function universal_bag_pickup(entity_who_kicked, active_item)
     end
     -- Pickup potions
     if ModSettingGet("BagsOfMany.allow_potions") then
-        local entities = EntityGetInRadiusWithTag(pos_x, pos_y, pickup_distance, "potion")
+        local entities = get_entities_with_material_inventory_in_radius(pos_x, pos_y, pickup_distance)
         add_potions_to_inventory(active_item, inventory, entity_who_kicked, entities)
     end
     -- Pickup items
@@ -55,7 +68,7 @@ function potion_bag_pickup(entity_who_kicked, active_item)
     local inventory = get_inventory(active_item)
     local pos_x, pos_y = EntityGetTransform(entity_who_kicked)
         -- Pickup potions
-    local entities = EntityGetInRadiusWithTag(pos_x, pos_y, pickup_distance, "potion")
+    local entities = get_entities_with_material_inventory_in_radius(pos_x, pos_y, pickup_distance)
     add_potions_to_inventory(active_item, inventory, entity_who_kicked, entities)
 end
 


### PR DESCRIPTION
# what this does
makes the quick pickup hotkey for bags register more items as potions. this doesn't change the items that can be carried, as you could always drag the item instead. now works on powder pouches as well as other modded material inventory items which do not use the potion tag.

![noita-20241209-231029-105379122-00004924](https://github.com/user-attachments/assets/b8c24d46-a7f9-4e95-a04e-ac1ff3821ca5)
![noita-20241209-231205-105379122-00010462](https://github.com/user-attachments/assets/b02578f0-d368-4030-af41-688db2e9a715)


# why it's good
convenience; QoL

# how it was tested
booted up a test world, and spawned in a variety of material inventory items, and verified that old behavior still works the same, and new behavior works the same. Tests were done using the big universal and potion bag
in particular, tested:
* potions [vanilla] {worked fine before}
* powder pouches [vanilla]  {hotkey did not work before}
* balloons [graham's things] {worked fine before}
* ampoules [electrum]  {hotkey did not work before}
* mestarialkemistipullo/stasis beaker [electrum]  {hotkey did not work before}