### PR TITLE
bag children component enabling fix

### DIFF
--- a/files/entities/bags/bag_potions_big.xml
+++ b/files/entities/bags/bag_potions_big.xml
@@ -66,6 +66,13 @@
         <InheritTransformComponent/>
     </Entity>
 
+    <!-- Throw bag -->
+	<LuaComponent
+        _tags="enabled_in_hand"
+        script_throw_item="mods/bags_of_many/files/scripts/bags/bags_throw_script.lua"
+        execute_every_n_frame="-1" >
+	</LuaComponent>
+	
 	<!-- item -->
 
 	<SpriteComponent

--- a/files/entities/bags/bag_potions_medium.xml
+++ b/files/entities/bags/bag_potions_medium.xml
@@ -73,6 +73,13 @@
         execute_every_n_frame="-1" >
 	</LuaComponent>	
 
+    <!-- Throw bag -->
+	<LuaComponent
+        _tags="enabled_in_hand"
+        script_throw_item="mods/bags_of_many/files/scripts/bags/bags_throw_script.lua"
+        execute_every_n_frame="-1" >
+	</LuaComponent>
+	
 	<!-- item -->
 
 	<SpriteComponent


### PR DESCRIPTION
# what this does
makes it so that medium and big potion bags enable the components of their children when thrown - as is the case with universal, spell, and the small potion bag

# why it's good
closes #8. means bags work more consistently, also cross-mod compatability

# how it was tested
spawned in medium and big potion bad and tested that components work properly
![noita-20241210-203727-1530528361-00008030](https://github.com/user-attachments/assets/f6addc4c-1a4d-4224-951b-ae4abbfc2d83)
