### PR TITLE
potions name fixes & some code cleanup

### DIFF
--- a/files/scripts/gui/bag_inventory.lua
+++ b/files/scripts/gui/bag_inventory.lua
@@ -1209,10 +1209,8 @@ function generate_tooltip(item)
         end
     elseif has_material_inventory(item) then
         local potion_fill_percent = get_potion_fill_percent(item)
-        --local potion_size = get_potion_size(item)
         local materials = get_potion_contents(item)
         if materials then
-			
 			local acomp=EntityGetFirstComponentIncludingDisabled(item, "AbilityComponent")
 			local entname= "POTION"
 			if acomp then
@@ -1223,15 +1221,11 @@ function generate_tooltip(item)
 				tooltip = "EMPTY " .. entname:upper()
 			else
 				tooltip=string.format("%s %s (%.2f FULL)",GameTextGetTranslatedOrNot(materials[1].name):upper(),entname:upper(),potion_fill_percent*100.0 )
-				
 			    for i = 1, #materials do
 					local material_name = GameTextGetTranslatedOrNot(materials[i].name)
 					tooltip=tooltip.. string.format("\n%.2f%% %s",materials[i].amount,material_name)
 				end
-
-			end 
-			
-            -- tooltip = tooltip .. "size : [" .. tostring(potion_size) .. "]\n"
+			end
         end
     else
         local item_component = EntityGetComponentIncludingDisabled(item, "ItemComponent")

--- a/files/scripts/gui/bag_inventory.lua
+++ b/files/scripts/gui/bag_inventory.lua
@@ -1222,8 +1222,7 @@ function generate_tooltip(item)
 			else
 				tooltip=string.format("%s %s (%.2f FULL)",GameTextGetTranslatedOrNot(materials[1].name):upper(),entname:upper(),potion_fill_percent*100.0 )
 			    for i = 1, #materials do
-					local material_name = GameTextGetTranslatedOrNot(materials[i].name)
-					tooltip=tooltip.. string.format("\n%.2f%% %s",materials[i].amount,material_name)
+					tooltip=tooltip.. string.format("\n%.2f%% %s",materials[i].amount,GameTextGetTranslatedOrNot(materials[i].name))
 				end
 			end
         end

--- a/files/scripts/gui/bag_inventory.lua
+++ b/files/scripts/gui/bag_inventory.lua
@@ -1214,7 +1214,7 @@ function generate_tooltip(item)
 			local acomp=EntityGetFirstComponentIncludingDisabled(item, "AbilityComponent")
 			local entname= "POTION"
 			if acomp then
-				entname = GameTextGetTranslatedOrNot(ComponentGetValue2(acomp, "ui_name") or entname):sub(4) -- potion names will translate start with $0 . probably for material reasons, but we aren't supplying that.
+				entname = GameTextGetTranslatedOrNot(ComponentGetValue2(acomp, "ui_name") or entname):gsub(" ?%$0 ?","",1) -- potion names will translate start with $0 . probably for material reasons, but we aren't supplying that.
 			end
 			
 			if #materials==0 then

--- a/files/scripts/gui/bag_inventory.lua
+++ b/files/scripts/gui/bag_inventory.lua
@@ -1209,24 +1209,28 @@ function generate_tooltip(item)
         end
     elseif has_material_inventory(item) then
         local potion_fill_percent = get_potion_fill_percent(item)
-        local potion_size = get_potion_size(item)
+        --local potion_size = get_potion_size(item)
         local materials = get_potion_contents(item)
         if materials then
-            local material_inv_type = "POTION"
-            if is_powder_stash(item) then
-                material_inv_type = "POUCH"
-            end
-            for i = 1, #materials do
-                local game_text = GameTextGet(materials[i].name)
-                if i == 1 then
-                    tooltip = tooltip .. string.upper(game_text) .. " " .. material_inv_type .. " (" .. string.format("%.2f", potion_fill_percent*100) .. "% FULL)" .. "\n"
-                end
-                local text_to_add = string.format("%.2f", materials[i].amount) .. "% " .. string.upper(game_text:sub(1,1)) .. game_text:sub(2, #game_text)
-                tooltip = tooltip .. text_to_add .. "\n"
-            end
-            if #materials <= 0 then
-                tooltip = tooltip .. "EMPTY " .. material_inv_type
-            end
+			
+			local acomp=EntityGetFirstComponentIncludingDisabled(item, "AbilityComponent")
+			local entname= "POTION"
+			if acomp then
+				entname = GameTextGetTranslatedOrNot(ComponentGetValue2(acomp, "ui_name") or entname):sub(4) -- potion names will translate start with $0 . probably for material reasons, but we aren't supplying that.
+			end
+			
+			if #materials==0 then
+				tooltip = "EMPTY " .. entname:upper()
+			else
+				tooltip=string.format("%s %s (%.2f FULL)",GameTextGetTranslatedOrNot(materials[1].name):upper(),entname:upper(),potion_fill_percent*100.0 )
+				
+			    for i = 1, #materials do
+					local material_name = GameTextGetTranslatedOrNot(materials[i].name)
+					tooltip=tooltip.. string.format("\n%.2f%% %s",materials[i].amount,material_name)
+				end
+
+			end 
+			
             -- tooltip = tooltip .. "size : [" .. tostring(potion_size) .. "]\n"
         end
     else


### PR DESCRIPTION
## what this does
* makes materials which do not use a translation key still appear in the UI
* makes potions in bags use their ui name instead of a generic name
* changes the code for displaying this information to be a bit more clear
## why it's good
visual clarity, futureproofing, mod compatability, translation support


## how it was tested
* placed a modded potion item into the bag and verified the name was the item's name
* placed a normal potion with a few materials in it to verify that existing behavior was not changed
* placed a potion with a keyless material in the bag to verify that the item name properly displays